### PR TITLE
Add the "minUnit" library to the "Debug" category

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [ig-debugheap](https://github.com/deplinenoise/ig-debugheap) - Multiplatform debug heap useful for tracking down memory errors.
 * [libtap](https://github.com/zorgnax/libtap) - Write tests in C.
 * [microprofile](https://bitbucket.org/jonasmeyer/microprofile/overview) - Profiler with web-view for multiple platforms.
+* [minUnit](http://www.jera.com/techinfo/jtns/jtn002.html) - A minimal unit testing framework for C written using only 2 macros.
 * [Remotery](https://github.com/Celtoys/Remotery) - Single C File Profiler with Web Viewer.
 
 ## Game Engine


### PR DESCRIPTION
Hello,

This pull request adds the library [minUnit](http://www.jera.com/techinfo/jtns/jtn002.html) to the "Debug" section.

This is an extremely simple library for unit testing, composed only of 2 macros.
