### PR TITLE
Add premake in build systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [Scons](http://www.scons.org/) - A software construction tool configured with Python scipt.
 * [tundra](https://github.com/deplinenoise/tundra) - High-performance code build system designed to give the best possible incremental build times even for very large software projects.
 * [tup](http://gittup.org/tup/) - File-based build system that monitors in the background for changed files.
-* [premake](http://industriousone.com/premake) - A tool configured with lua scipt to generate project files for Visual Studio, GNU Make, Xcode, Code::Blocks, and more across Windows, Mac OS X, and Linux.
+* [Premake](http://industriousone.com/premake) - A tool configured with lua scipt to generate project files for Visual Studio, GNU Make, Xcode, Code::Blocks, and more across Windows, Mac OS X, and Linux.
 
 ## Static Code Analysis
 *List of tools for improving quality and reducing defects by code analysis*


### PR DESCRIPTION
I think Premake is a cool tool that can generate project files for Visual Studio, GNU Make, Xcode, Code::Blocks, and more across Windows, Mac OS X, and Linux.  
