### PR TITLE
Add nanomsg and libtask

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [Apache Thrift](https://thrift.apache.org/) - Efficient cross-language IPC/RPC, works between C++, Java, Python, PHP, C#, and many more other languages. Originally developed by Twitter. [Apache2]
 * [Cap'n Proto](http://kentonv.github.io/capnproto/) - Fast data interchange format and capability-based RPC system. [MIT]
 * [libjson-rpc-cpp](https://github.com/cinemast/libjson-rpc-cpp) - JSON-RPC framework for C++ servers and clients. [MIT]
+* [nanomsg](http://nanomsg.org/) - A socket library that provides several common communication patterns. [MIT/X11]
 * [simple-rpc-cpp](https://code.google.com/p/simple-rpc-cpp/) - A simple RPC wrapper generator to C/C++ functions. [BSD]
 * [xmlrpc-c](http://xmlrpc-c.sourceforge.net/) - A lightweight RPC library based on XML and HTTP. [BSD]
 * [ZeroMQ](http://zeromq.org/) - High-speed, modular asynchronous communication library. [LGPL]

--- a/todo3.txt
+++ b/todo3.txt
@@ -7,3 +7,5 @@ https://mattmccutchen.net/bigint/
 https://code.google.com/p/infint/
 http://cpp-bigint.sourceforge.net/
 https://gmplib.org/
+
+http://swtch.com/libtask/


### PR DESCRIPTION
nanomsg is something like ZeroMQ. 

Recently, I am learning ZeroMQ. When searcing "PUB SUB", I found this article(in Chinse):
 [Crossroads I/O中的Pub/Sub子系统](http://wangjunle23.blog.163.com/blog/static/11783817120129160021602/)

From this page, I got to know that there is also a message queue library named `Crossroads I/O`.

Then I searched 'Crossroads I/O' in Google and found this page:
[ZeroMQ vs Crossroads I/O](http://stackoverflow.com/questions/13494033/zeromq-vs-crossroads-i-o
)

This is where I read about nanomsg.
