### PR TITLE
Add lmdb++, a C++11 wrapper for LMDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [Hiredis](https://github.com/redis/hiredis) - A minimalistic C client library for the Redis database. [BSD]
 * [LevelDB](https://github.com/google/leveldb) - A fast key-value storage library. [BSD]
 * [LMDB](http://symas.com/mdb/) - Very fast embedded key/value store with full ACID semantics. [OpenLDAP]
+* [LMDB++](https://github.com/bendiken/lmdbxx) - C++11 wrapper for the LMDB embedded database library. [PublicDomain]
 * [MongoDB C Driver](https://github.com/mongodb/mongo-c-driver) - MongoDB client library for C. [Apache2]
 * [MongoDB C++ Driver](https://github.com/mongodb/mongo-cxx-driver) - C++ driver for MongoDB. [Apache2]
 * [MongoDB Libbson](https://github.com/mongodb/libbson) - A BSON utility library. [Apache2]


### PR DESCRIPTION
Since LMDB is already listed, please add the C++ wrapper as well: https://github.com/bendiken/lmdbxx

This is a comprehensive C++ wrapper for the LMDB embedded B+ tree database library, offering both an error-checked procedural interface and an object-oriented resource interface with RAII semantics. Designed to be entirely self-contained as a single `<lmdb++.h>` header file that can be dropped into a project, and made available as free and unencumbered public domain software.