### PR TITLE
Fix #82: Use regex to remove hyphens from fragment identifiers

### DIFF
--- a/assets/awesome-cpp.js
+++ b/assets/awesome-cpp.js
@@ -5,6 +5,7 @@ var getFileData = function(url) {
       "Accept": "application/vnd.github.v3.raw"
     }
   }).done(function(data) {
+    data = data.replace(/(\(#\w+)-/g, "$1").replace(/(\(#\w+)-/g, "$1");
     var converter = new Showdown.converter();
     var html = converter.makeHtml(data);
     $("#content").html(html)


### PR DESCRIPTION
`replace` is used twice as JavaScript regex cannot recurse, though I don't deny a better regex may exist.