### PR TITLE
Fix link location for googletest and googlemock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [CMocka](https://cmocka.org/) - unit testing framework for C with support for mock objects. [Apache2]
 * [CppUnit](http://www.freedesktop.org/wiki/Software/cppunit/) - C++ port of JUnit. [LGPL2]
 * [CTest](http://www.cmake.org/cmake/help/v2.8.8/ctest.html) - The CMake test driver program. [BSD]
-* [googlemock](http://code.google.com/p/googlemock/) - A library for writing and using C++ mock classes. [BSD]
-* [googletest](http://code.google.com/p/googletest/) - Google C++ Testing Framework. [BSD]
+* [googlemock](https://github.com/google/googletest/blob/master/googlemock/README.md) - A library for writing and using C++ mock classes. [BSD]
+* [googletest](https://github.com/google/googletest) - Google C++ Testing Framework. [BSD]
 * [ig-debugheap](https://github.com/deplinenoise/ig-debugheap) - Multiplatform debug heap useful for tracking down memory errors. [BSD]
 * [libtap](https://github.com/zorgnax/libtap) - Write tests in C. [GPL2]
 * [MemTrack](http://www.almostinfinite.com/memtrack.html) - Tracking memory allocations in C++.


### PR DESCRIPTION
The Google Mock framework has been absorbed into the Google Test project, available on GH.