### PR TITLE
Added awesome icon linking to sindresorhus/awesome and removed the line "Inspired by awesome-... stuff."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Awesome C/C++
-A curated list of awesome C/C++ frameworks, libraries, resources, and shiny things. Inspired by awesome-... stuff.
+# Awesome C/C++ [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+
+A curated list of awesome C/C++ frameworks, libraries, resources, and shiny things.
 
 - [Awesome C/C++](#awesome-cpp)
 	- [Standard Libraries](#standard-libraries)


### PR DESCRIPTION
sindresorhus/awesome is a curated list of awesome lists, which also lists ffaraz/awesome-cpp under C/C++. The individual lists link to the list of lists using this icon. E.g. akullpp/awesome-java, sorrycc/awesome-javascript etc.