### PR TITLE
Microsoft Casablanca -> C++ REST SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 
 * [ACE](http://www.cs.wustl.edu/~schmidt/ACE.html) - An OO Network Programming Toolkit in C++. [?MIT?]
 * [Boost.Asio](http://think-async.com/) :zap: - A cross-platform C++ library for network and low-level I/O programming. [Boost]
-* [Casablanca](http://casablanca.codeplex.com/) - C++ REST SDK. [Apache2]
+* [C++ REST SDK](https://github.com/Microsoft/cpprestsdk) - C++ REST SDK (previously named Casablanca). [Apache2]
 * [cpp-netlib](http://cpp-netlib.org/) - A collection of open-source libraries for high level network programming. [Boost]
 * [cpr](https://github.com/whoshuu/cpr) - A modern C++ HTTP requests library with a simple but powerful interface. Modeled after the Python Requests module. [MIT] [website](https://whoshuu.github.io/cpr/)
 * [Dyad.c](https://github.com/rxi/dyad) - Asynchronous networking for C. [MIT]


### PR DESCRIPTION
Casablanca by Microsoft was renamed to C++ REST SDK and moved to GitHub