### PR TITLE
Add cppcodec, a C++11 header-only base-N encoding library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 ## Serialization
 
 * [cereal](https://github.com/USCiLab/cereal) - A C++11 library for serialization. [BSD]
+* [cppcodec](https://github.com/tplgy/cppcodec) - Header-only C++11 library to encode/decode base64, base32 and hex with consistent, flexible API. [MIT]
 * [FlatBuffers](https://github.com/google/flatbuffers) - A Memory efficient serialization library. [Apache2]
 * [MessagePack](https://github.com/msgpack/msgpack-c) - Efficient binary serialization format "like JSON" for C/C++. [Apache2] [website](http://msgpack.org/)
 * [protobuf](https://github.com/google/protobuf) - Protocol Buffers - Google's data interchange format. [BSD]


### PR DESCRIPTION
I was actually surprised not to see any base64 library in the list even, although I guess some libraries might ship with one.

Disclaimer: I wrote this library myself, so please have a look whether it meets your criteria.

That said, it's comprehensive, documented, tested, easy to use/include and decidedly C++, more so than most other (usually codec-specific) libraries I've seen. Hope it can go into the list!