### PR TITLE
Fix broken link to Google C++ Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines) - "Official" set of C++ guidelines, reviewed by the author of C++.
 * [C++ Dos and Don'ts](http://www.chromium.org/developers/coding-style/cpp-dos-and-donts) - The Chromium Projects > For Developers > Coding Style > C++ Dos and Don'ts.
 * [google-styleguide](https://github.com/google/styleguide) - Style guides for Google-originated open-source projects.
-* [Google C++ Style Guide](http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml)
+* [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
 * [GNU Coding Standard](http://www.gnu.org/prep/standards/standards.html)
 * [Linux kernel coding style](https://www.kernel.org/doc/Documentation/CodingStyle)
 * [LLVM Coding Standards](http://llvm.org/docs/CodingStandards.html)


### PR DESCRIPTION
Previous [link](http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml) is old, and I think that it will no longer be supported.