### PR TITLE
Updated tesseract-ocr URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [OpenCV](http://opencv.org/) :zap: - Open source computer vision. [BSD]
 * [OpenEXR](http://www.openexr.com/) - Cross-platform library for high dynamic range imaging. [Modified BSDF]
 * [OpenImageIO](https://github.com/OpenImageIO/oiio) - Powerful image and texture wrangling library with support for a wide number of common lossy and RAW formats. [Modified BSD]
-* [tesseract-ocr](https://code.google.com/p/tesseract-ocr/) - An OCR engine. [Apache2]
+* [tesseract-ocr](https://github.com/tesseract-ocr) - An OCR engine. [Apache2]
 * [Video++](https://github.com/matt-42/vpp) - A C++14 high performance video and image processing library. [MIT]
 * [VIGRA](https://github.com/ukoethe/vigra) - A generic C++ computer vision library for image analysis. [MIT X11]
 * [VTK](http://www.vtk.org/) - Open-source, freely available software system for 3D computer graphics, image processing and visualization. [BSD]


### PR DESCRIPTION
**tesseract-ocr** has moved from [https://code.google.com/p/tesseract-ocr/](https://code.google.com/p/tesseract-ocr/) to [https://github.com/tesseract-ocr](https://github.com/tesseract-ocr).