### PR TITLE
Add hopscotch map to the list of containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 
 * [C++ B-tree](https://code.google.com/p/cpp-btree/) - A template library that implements ordered in-memory containers based on a B-tree data structure. [Apache2]
 * [Hashmaps](https://github.com/goossaert/hashmap) - Implementation of open addressing hash table algorithms in C++. [MIT]
+* [Hopscotch map](https://github.com/Tessil/hopscotch-map) - A fast header-only hash map which uses hopscotch hashing for collisions resolution. [MIT]
 * [LSHBOX](https://github.com/RSIA-LIESMARS-WHU/LSHBOX) - A c++ toolbox of locality-sensitive hashing (LSH), provides several popular LSH algorithms, also support Python and MATLAB. [GPL]
 
 ## Cryptography


### PR DESCRIPTION
Add [hopscotch map](https://github.com/Tessil/hopscotch-map) which is a header-only hash map using hopscotch hashing for collisions resolution.