### PR TITLE
Update link of tiny-dnn framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [Evolving Objects](http://eodev.sourceforge.net/) - A template-based, ANSI-C++ evolutionary computation library which helps you to write your own stochastic optimization algorithms insanely fast. [LGPL]
 * [Recast/Detour](https://github.com/recastnavigation/recastnavigation) - (3D) Navigation mesh generator and pathfinder, mostly for games. [zlib]
 * [TensorFlow](https://github.com/tensorflow/tensorflow) - An open source software library for numerical computation using data flow graphs [Apache]
-* [tiny-cnn](https://github.com/nyanp/tiny-cnn) - A header only, dependency-free deep learning framework in C++11. [BSD]
+* [tiny-dnn](https://github.com/tiny-dnn/tiny-dnn) - A header only, dependency-free deep learning framework in C++11. [BSD]
 * [Veles](https://github.com/Samsung/veles) - Distributed platform for rapid Deep learning application development. [Apache]
 
 ## Asynchronous Event Loop


### PR DESCRIPTION
The repository was renamed and transferred to an organization.