### PR TITLE
Add alpaka & cupla

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,14 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 ## Concurrency
 *Concurrency and Multithreading*
 
+* [alpaka](https://github.com/ComputationalRadiationPhysics/alpaka) - Abstraction library for parallel kernel acceleration. [LGPLv3+]
 * [ArrayFire](https://github.com/arrayfire/arrayfire) - A general purpose GPU library. [BSD]
 * [Boost.Compute](https://github.com/boostorg/compute) - A C++ GPU Computing Library for OpenCL. [Boost]
 * [Bolt](https://github.com/HSA-Libraries/Bolt) - A C++ template library optimized for GPUs. [Apache2]
 * [ck](https://github.com/concurrencykit/ck) - Concurrency primitives, safe memory reclamation mechanisms and non-blocking data structures. [BSD]
 * [concurrentqueue](https://github.com/cameron314/concurrentqueue) - A fast multi-producer, multi-consumer lock-free concurrent queue for C++11. [BSD,Boost]
 * [CUB](https://github.com/NVlabs/cub) - CUB provides state-of-the-art, reusable software components for every layer of the CUDA programming mode. [New BSD]
+* [cupla](https://github.com/ComputationalRadiationPhysics/cupla) - C++ API to run CUDA/C++ on OpenMP, Threads, TBB, ... through Alpaka. [LGPLv3+]
 * [C++React](https://github.com/schlangster/cpp.react) - A reactive programming library for C++11. [Boost]
 * [Intel TBB](https://www.threadingbuildingblocks.org/) - Intel® Threading Building Blocks. [Apache2]
 * [junction](https://github.com/preshing/junction) - A library of concurrent data structures in C++. [BSD]


### PR DESCRIPTION
[**alpaka**](https://github.com/ComputationalRadiationPhysics/alpaka) and [**cupla**](https://github.com/ComputationalRadiationPhysics/cupla) are two coupled libraries that allow programming accelerator hardware (GPUs, Xeon Phi, etc.) via a common, single-source, performance-portable, standard C++11 programming model.

alpaka/cupla are used in various scientific codes, e.g. [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu), [HASEonGPU](https://github.com/ComputationalRadiationPhysics/haseongpu), [ISAAC](https://github.com/ComputationalRadiationPhysics/isaac) and [Mephisto](https://mephisto-hpc.de).

A list of publications (including OA links) explain the concepts behind alpaka/cupla:

* DOI:10.1109/IPDPSW.2016.50 (http://arxiv.org/abs/1602.08477),
  paper in AsHES2016

* DOI:[10.5281/zenodo.49768](https://doi.org/10.5281/zenodo.49768) (thesis: diploma)

* DOI:10.1007/978-3-319-67630-2_36 (https://arxiv.org/abs/1706.10086),
  paper in ISC17 (P3MA)

* DOI:10.1007/978-3-319-46079-6_21 (https://arxiv.org/abs/1606.02862),
  paper in ISC16 (IWOPH)

* Live-Porting from CUDA to alpaka/cupla, talk in GTC2016:
  https://mygtc.gputechconf.com/events/32/schedules/2792
  Video: http://on-demand.gputechconf.com/gtc/2016/video/S6298.html

We would be glad if you accept us for addition in your awesome list ✨ 