### PR TITLE
Add Spack

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ A curated list of awesome C/C++ frameworks, libraries, resources, and shiny thin
 * [Ninja](https://ninja-build.org/) - A small build system with a focus on speed.
 * [Scons](http://www.scons.org/) - A software construction tool configured with a Python script.
 * [Sconsolidator](http://www.sconsolidator.com/) - Scons build system integration for Eclipse CDT.
+* [Spack](https://spack.io/) - A flexible package manager that supports multiple versions, configurations, platforms, and compilers. [LGPLv2.1]
 * [tundra](https://github.com/deplinenoise/tundra) - High-performance code build system designed to give the best possible incremental build times even for very large software projects.
 * [tup](http://gittup.org/tup/) - File-based build system that monitors in the background for changed files.
 * [Premake](http://premake.github.io) - A tool configured with a Lua script to generate project files for Visual Studio, GNU Make, Xcode, Code::Blocks, and more across Windows, Mac OS X, and Linux.


### PR DESCRIPTION
[Spack](https://spack.io) is a flexible package manager that supports multiple versions, configurations, platforms, and compilers. It's perfectly suited for complex software toolchains as often seen on clusters and seamlessly allows to combine C/C++, Fortran, Python, R, ... projects and bindings with a high user-control on variants, flags and dependencies of all packages.