### PR TITLE
Change C++ Awesome Pack url

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 
 * [algorithms](https://github.com/xtaci/algorithms) - Algorithms & Data Structures in C++.
 * [c-algorithms](https://github.com/fragglet/c-algorithms) - C algorithms library.
-* [C++ Awesome Pack](https://github.com/JunianNet/CppAwesomePack) - Contains some awesome c++ codes, packed in one.
+* [C++ Awesome Pack](https://github.com/juniandotnet/cpp-awesome-pack) - Contains some awesome c++ codes, packed in one.
 
 # Other Awesome Lists
 *Other amazingly awesome lists*


### PR DESCRIPTION
The url for C++ Awesome Pack is changed to new organization and different project name.