### PR TITLE
Build Systems: Add clib, waf

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Bazel](https:/bazel.build) - A multi-language, fast and scalable build system from Google. [Apache]
 * [Bear](https://github.com/rizsotto/Bear) - A tool to generate compilation database for clang tooling. [GPLv3]
 * [cget](https://github.com/pfultz2/cget) - Cmake package retrieval used to download and install cmake packages. [Boost]
+* [clib](https://github.com/clibs/clib) - Package manager for the C programming language. [MIT]
 * [CMake](https://cmake.org/) - Cross-platform free and open-source software for managing the build process of software using a compiler-independent method. [BSD]
 * [C++ Archive Network](https://cppan.org/) - Cross-platform C++ Dependency Manager with a lot of packages available.
 * [Conan](https://conan.io/) - C/C++ Package Manager, open sourced. [MIT]

--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [tup](http://gittup.org/tup/) - File-based build system that monitors in the background for changed files.
 * [Premake](http://premake.github.io) - A tool configured with a Lua script to generate project files for Visual Studio, GNU Make, Xcode, Code::Blocks, and more across Windows, Mac OS X, and Linux.
 * [Vcpkg](https://github.com/microsoft/vcpkg) - VC++ Packaging Tool for Windows.
+* [waf](https://github.com/waf-project/waf) - Python-based framework for configuring, compiling and installing applications. [BSD] [website](https://waf.io/)
 
 ## Static Code Analysis
 *List of tools for improving quality and reducing defects by code analysis*


### PR DESCRIPTION
Build Systems
=====
* [clib](https://github.com/clibs/clib) - Package manager for the C programming language. [MIT]
* [waf](https://github.com/waf-project/waf) - Python-based framework for configuring, compiling and installing applications. [BSD] [website](https://waf.io/)