### PR TITLE
Add mini_al

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [FMOD](http://www.fmod.org/) - An easy to use crossplatform audio engine and audio content creation tool for games. [Free for non-commercial/Commercial]
 * [KFR](https://www.kfrlib.com/) - Fast, modern C++ DSP framework, FFT, FIR/IIR filters, Sample Rate Conversion. [GPL/Commercial]
 * [Maximilian](https://github.com/micknoise/Maximilian) - C++ Audio and Music DSP Library. [MIT]
+* [mini_al](https://github.com/dr-soft/mini_al) - Single file audio playback and capture library. [Unlicense]
 * [OpenAL](http://www.openal.org/) - Open Audio Library - A crossplatform audio API. [BSD/LGPL/Commercial]
 * [Opus](http://opus-codec.org/) - A totally open, royalty-free, highly versatile audio codec. [BSD]
 * [SELA](https://github.com/sahaRatul/sela) - SimplE Lossless Audio. [MIT]


### PR DESCRIPTION
I was pinged about adding mini_al. Here's my response in the form of a pull request.

mini_al (https://github.com/dr-soft/mini_al) is a single file audio playback and capture library.