### PR TITLE
Add the facil.io framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ array expressions, inspired by NumPy syntax. [BSD 3-clause] [website](http://qua
 * [CppCMS](http://cppcms.com/) - A Free High Performance Web Development Framework (not a CMS). [LGPLv3]
 * [Crow](https://github.com/ipkn/crow) - Crow is C++ micro web framework (inspired by Python Flask). [BSD]
 * [Cutelyst](https://github.com/cutelyst/cutelyst) - A C++ Web Framework built on top of Qt, using the simple approach of Catalyst (Perl) framework. [LGPLv2.1+] [website](https://cutelyst.org/)
+* [facil.io](https://github.com/boazsegev/facil.io) - Evented, high performance C web framework supporting HTTP, WebSockets, SSE and more. [MIT] [website](http://facil.io)
 * [Kore](https://kore.io/) - ultra fast and flexible web server / framework for web applications developed in C. [ISC]
 * [libOnion](http://www.coralbits.com/libonion/) - lightweight library to help you create webservers in C programming language. [LGPLv3]
 * [lwan](https://github.com/lpereira/lwan) - Experimental, scalable, high performance HTTP server. [GPL2]


### PR DESCRIPTION
Hi! Thanks for a great list 👍🏻

I'm proposing to add the facil.io framework which is an evened web framework written in C.

The framework is used to power the [iodine Ruby server](https://github.com/boazsegev/iodine) which focuses on serving real-time applications.

It's MIT licensed and free (as in freedom, as well as - I guess - beer).

Visit the [website for more information](http://facil.io).

Thanks for your consideration.
   B.