### PR TITLE
Updated the miniz link and adjusted the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [LZHAM](https://code.google.com/p/lzham/) - Lossless data compression library with a compression ratio similar to LZMA but with much faster decompression. [BSD]
 * [LZMA](http://www.7-zip.org/sdk.html) :zap: - The default and general compression method of 7z format. [PublicDomain]
 * [LZMAT](http://www.matcode.com/lzmat.htm) - An extremely fast real-time lossless data compression library. [GPL]
-* [miniz](https://code.google.com/p/miniz/) - Single C source file Deflate/Inflate compression library with zlib-compatible API, ZIP archive reading/writing, PNG writing. [Unlicense]
+* [miniz](https://github.com/richgel999/miniz) - Single C source file Deflate/Inflate compression library with zlib-compatible API, ZIP archive reading/writing, PNG writing. [MIT]
 * [Minizip](https://github.com/nmoinvaz/minizip) - Zlib with latest bug fixes that supports PKWARE disk spanning, AES encryption, and IO buffering. [zlib]
 * [smaz](https://github.com/antirez/smaz) - Small strings compression library. [BSD]
 * [Snappy](https://google.github.io/snappy/) - A fast compressor/decompressor. [BSD]


### PR DESCRIPTION
Fixes #687 

Google Code has been shutdown for a while, miniz has been continued on [GitHub](https://github.com/richgel999/miniz).
Due to adding ZIP64 support, which came from valve's vogl project, the license was changed to MIT.
https://richg42.blogspot.com/2014/03/zip64-version-of-miniz-library-released.html