### PR TITLE
Remove cplusplus.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,7 +988,6 @@ array expressions, inspired by NumPy syntax. [BSD 3-clause] [website](http://qua
 * [Standard C++](https://isocpp.org/) :zap: - News, Status & Discussion about Standard C++.
 * [CppCon](http://cppcon.org/) - The C++ Conference.
 * [C++ reference](http://cppreference.com/) - C++98, C++03, C++11, C++14 reference.
-* [cplusplus.com](http://www.cplusplus.com/) - The C++ Resources Network.
 * [C FAQ](http://c-faq.com/) - C frequently asked questions.
 * [C++ FAQ](http://www.parashift.com/c++-faq/) - C++ frequently asked questions.
 * [C++ FQA Lite](http://yosefk.com/c++fqa/) - C++ frequently questioned answers.


### PR DESCRIPTION
cplusplus.com has a bad reputation in the community for sharing misinformation and bad practices.

On this topic:
- https://stackoverflow.com/questions/6520052/whats-wrong-with-cplusplus-com
- https://www.reddit.com/r/learnprogramming/comments/1maa87/why_is_cpluspluscom_bad/
- https://meta.stackexchange.com/questions/194788/links-being-changed-to-cppreference-com