### PR TITLE
Updated zeromq entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,6 @@ array expressions, inspired by NumPy syntax. [BSD 3-clause] [website](http://qua
 * [cpp-httplib](https://github.com/yhirose/cpp-httplib) - A single file C++11 header-only HTTP/HTTPS sever library. [MIT]
 * [cpp-netlib](http://cpp-netlib.org/) - A collection of open-source libraries for high level network programming. [Boost]
 * [cpp-netlib/uri](https://github.com/cpp-netlib/uri) - URI parser/builder library for C++, compatible with RFC 3986 and RFC 3987. [BSL-1.0]
-* [ZeroMQ](http://zeromq.org/bindings:cpp) - High-speed, modular asynchronous communication library. [LGPL]
 * [cpr](https://github.com/whoshuu/cpr) - A modern C++ HTTP requests library with a simple but powerful interface. Modeled after the Python Requests module. [MIT] [website](https://whoshuu.github.io/cpr/)
 * [curlcpp](https://github.com/JosephP91/curlcpp) - An object oriented C++ wrapper for CURL(libcurl). [MIT]
 * [Dyad.c](https://github.com/rxi/dyad) - Asynchronous networking for C. [MIT]
@@ -624,6 +623,7 @@ array expressions, inspired by NumPy syntax. [BSD 3-clause] [website](http://qua
 * [wdt](https://github.com/facebook/wdt) - An embeddedable library (and command line tool) aiming to transfer data between 2 systems as fast as possible over multiple TCP paths. [BSD-3-Clause]
 * [WebSocket++](https://github.com/zaphoyd/websocketpp) - C++/Boost Asio based websocket client/server library. [BSD]
 * [PcapPlusPlus](https://github.com/seladb/PcapPlusPlus) - a multiplatform C++ network sniffing and packet parsing and crafting framework. [Unlicense]
+* [ZeroMQ](http://zeromq.org/bindings:cpp) - High-speed, modular asynchronous communication library. [LGPL] [website](http://zeromq.org/)
 
 ## PDF
 *Libraries for parsing and manipulating PDF documents.*

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ array expressions, inspired by NumPy syntax. [BSD 3-clause] [website](http://qua
 * [wdt](https://github.com/facebook/wdt) - An embeddedable library (and command line tool) aiming to transfer data between 2 systems as fast as possible over multiple TCP paths. [BSD-3-Clause]
 * [WebSocket++](https://github.com/zaphoyd/websocketpp) - C++/Boost Asio based websocket client/server library. [BSD]
 * [PcapPlusPlus](https://github.com/seladb/PcapPlusPlus) - a multiplatform C++ network sniffing and packet parsing and crafting framework. [Unlicense]
-* [ZeroMQ](http://zeromq.org/bindings:cpp) - High-speed, modular asynchronous communication library. [LGPL] [website](http://zeromq.org/)
+* [ZeroMQ](https://github.com/zeromq/libzmq) - High-speed, modular asynchronous communication library. [LGPL] [website](http://zeromq.org/)
 
 ## PDF
 *Libraries for parsing and manipulating PDF documents.*

--- a/README.md
+++ b/README.md
@@ -462,7 +462,6 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [simple-rpc-cpp](https://github.com/pearu/simple-rpc-cpp) - A simple RPC wrapper generator to C/C++ functions. [BSD]
 * [WAMP](http://wamp.ws/) - Provides RPC and pub/sub messaging patterns. (various implementations, various languages)
 * [xmlrpc-c](http://xmlrpc-c.sourceforge.net/) - A lightweight RPC library based on XML and HTTP. [BSD]
-* [ZeroMQ](http://zeromq.org/) - High-speed, modular asynchronous communication library. [LGPL]
 
 ## JSON
 
@@ -592,6 +591,7 @@ array expressions, inspired by NumPy syntax. [BSD 3-clause] [website](http://qua
 * [cpp-httplib](https://github.com/yhirose/cpp-httplib) - A single file C++11 header-only HTTP/HTTPS sever library. [MIT]
 * [cpp-netlib](http://cpp-netlib.org/) - A collection of open-source libraries for high level network programming. [Boost]
 * [cpp-netlib/uri](https://github.com/cpp-netlib/uri) - URI parser/builder library for C++, compatible with RFC 3986 and RFC 3987. [BSL-1.0]
+* [ZeroMQ](http://zeromq.org/bindings:cpp) - High-speed, modular asynchronous communication library. [LGPL]
 * [cpr](https://github.com/whoshuu/cpr) - A modern C++ HTTP requests library with a simple but powerful interface. Modeled after the Python Requests module. [MIT] [website](https://whoshuu.github.io/cpr/)
 * [curlcpp](https://github.com/JosephP91/curlcpp) - An object oriented C++ wrapper for CURL(libcurl). [MIT]
 * [Dyad.c](https://github.com/rxi/dyad) - Asynchronous networking for C. [MIT]


### PR DESCRIPTION
Zeromq is more than just for IPC, so I moved it to a more general section (Networking).
Also updated the link to point to the cpp bindings rather than the main website.