### PR TITLE
feat: Add Quantum++ To Physics Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [PhysX](https://github.com/NVIDIAGameWorks/PhysX-3.4) - An open-source realtime physics engine middleware SDK developed by Nvidia as a part of Nvidia GameWorks software suite. [BSD-3-Clause] 
 * [Project Chrono](https://github.com/projectchrono/chrono) - An open source multi-physics simulation engine. [BSD-3-Clause] [website](https://projectchrono.org/)
 * [Simbody](https://github.com/simbody/simbody) - High-performance C++ multibody dynamics/physics library for simulating articulated biomechanical and mechanical systems like vehicles, robots, and the human skeleton. [Apache2]
+* [Quantum++](https://github.com/vsoftco/qpp) - A modern C++11 quantum computing library. [MIT]
 
 ## Reflection
 


### PR DESCRIPTION
Quantum++ is a modern C++11 general purpose quantum computing library, composed solely of template header files. Quantum++ is written in standard C++11 and has very low external dependencies, using only the Eigen 3 linear algebra header-only template library and, if available, the OpenMP multi-processing library.