### PR TITLE
Add portable_concurrency library

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [libev](http://libev.schmorp.de/) - A full-featured and high-performance event loop that is loosely modelled after libevent, but without its limitations and bugs. [BSD and GPL]
 * [libevent](http://libevent.org/) - An event notification library. [BSD]
 * [libuv](https://github.com/libuv/libuv) - Cross-platform asynchronous I/O. [BSD]
+* [portable_concurrency](https://github.com/VestniK/portable_concurrency) - Extended future/promise API. [CC0]
 * [promise-cpp](https://github.com/xhawk18/promise-cpp) - Header only library that implements Promise/A+ standard. [Anti-996]
 * [uvw](https://github.com/skypjack/uvw) - C++ wrapper for libuv. [MIT]
 


### PR DESCRIPTION
It's way more usable then standard future/promise. It has when_all, when_any, executors support, cancellation and more.