### PR TITLE
Add SmartDec SAST tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Linticator](http://linticator.com) - Eclipse CDT integration of Pc-/FlexeLint.
 * [IKOS](https://github.com/NASA-SW-VnV/ikos) - Static analyzer for C/C++ based on the theory of Abstract Interpretation. [NOSA 1.3]
 * [List of tools for static code analysis](https://en.wikipedia.org/wiki/List_of_tools_for_static_code_analysis#C.2FC.2B.2B) - A list of tools for static code analysis from Wikipedia.
+* [SmartDec Scanner](https://smartdecscanner.com/) - SAST tool which is capable of identifying vulnerabilities and undocumented features. The analyzer scans the source code and executables without debug info (i.e. binaries). Supports 31 programming languages, including C, C++, C#, and Objective-C.
 
 ## Coding Style Tools
 


### PR DESCRIPTION
Although initially the PR was rejected, currently there is no clear point on why it has been determined that SmartDec Scanner doesn't suits to this list. Thus we propose reopening the issue for gathering more discussion details into it.

SmartDec Scanner is a SAST tool which is capable of identifying vulnerabilities and backdoors (undocumented features). Its distinctive feature is the ability to analyze not only source code but also executables without debug info (i.e. binaries) and to return much better results than when using DAST. The analyzer can test apps written in more than 30 programming languages or that have been compiled into an executable file with one of nine supported extensions, including those for Google Android, Apple iOS, and Apple macOS. SmartDec Scanner also can be easily integrated into a Secure SDLC process.

SmartDec Scanner does run a vast variety of checks, automating vulnerability discovery as well as detecting generic errors and discrepancies with recommended code writing practices. For instance, C++ engine is able detect safety, performance, thread safety and portability issues and to check the code base against best practices guidelines, such as C++ Core Guidelines. Such checks obviously does help C++ developers better understand language semantics as well as properties of their code base and ensure guideline acceptance for it.

Please let us know if you need any further details.

Summing up, we would be grateful if you could elaborate on the acceptance criteria for program analysis products and tooling in general. This would also help future contributors understand requirements for getting into the list, thus making the C++ community a greater place 👍