### PR TITLE
Add Phpack library

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [FlatBuffers](https://github.com/google/flatbuffers) - A Memory efficient serialization library. [Apache2]
 * [MessagePack](https://github.com/msgpack/msgpack-c) - Efficient binary serialization format "like JSON" for C and C++. [Apache2] [website](http://msgpack.org/)
 * [nanopb](https://github.com/nanopb/nanopb) - Small code-size Protocol Buffers implementation in ANSI C. [Zlib]
+* [phpack](https://github.com/Waqar144/phpack) - PHP pack() / unpack() for C++ 
 * [protobuf](https://github.com/protocolbuffers/protobuf) - Protocol Buffers - Google's data interchange format. [BSD]
 * [protobuf-c](https://github.com/protobuf-c/protobuf-c) - Protocol Buffers implementation in C. [BSD]
 * [SimpleBinaryEncoding](https://github.com/real-logic/simple-binary-encoding) - encoding and decoding application messages in binary format for low-latency applications. [Apache2]


### PR DESCRIPTION
- [PhPack](https://github.com/Waqar144/phpack) - Phpack library provides PHP's `pack()` / `unpack()` functions for C++. [MIT]