### PR TITLE
Add USRefl library

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Nameof](https://github.com/Neargye/nameof) - Header-only C++17 library provides nameof macros and functions to obtain the simple name of variable, type, function, macro, and enum. [MIT]
 * [Ponder](https://github.com/billyquith/ponder) - A C++11 library for reflection. [MIT]
 * [RTTR](https://github.com/rttrorg/rttr) - A C++11 library for reflection. [MIT] [website](http://www.rttr.org)
+* [USRefl](https://github.com/Ubpa/USRefl) - Header-only, tiny (99 lines) and powerful C++17 static reflection library. [MIT]
 * [visit_struct](https://github.com/cbeck88/visit_struct) - A miniature library for struct-field reflection in C++. [BSL-1.0]
 
 ## Regular Expression


### PR DESCRIPTION
[USRefl](https://github.com/Ubpa/USRefl) is a header-only, tiny (99 lines) and powerful C++17 static reflection library.
**Features**
- tiny, head-only, elegant (only 99 lines [USRefl_99.h](include/USRefl_99.h))
- noninvasive
- basic
  - (non-static / static) member variable
  - (non-static / static) member function
- attribute
- enum
  - string <-> key
  - static dispatch
- template
- inheritance
  - diamond inheritance
  - iterate bases recursively