### PR TITLE
Add BitConverter to Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,6 +831,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 
 ## Serialization
 
+* [BitConverter](https://github.com/YanjieHe/BitConverter) - A header-only C++ library for conversion between base data types and bytes.
 * [Bitsery](https://github.com/fraillt/bitsery) - Header only C++ binary serialization library. [MIT]
 * [Bond](https://github.com/Microsoft/bond) - An open source, cross-platform framework for working with schematized data. [MIT]
 * [Boost.Serialization](https://www.boost.org/doc/libs/master/libs/serialization/doc/index.html) - Boost Serialization Library. [Boost]


### PR DESCRIPTION
BitConverter is a C++ port of the C# BitConverter class. It is a header-only library for conversion between base data types and bytes.