### PR TITLE
Add GLFWPP library

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Diligent Engine](https://github.com/DiligentGraphics/DiligentEngine) - A modern cross-platform low-level 3D graphics library. [Apache2]
 * [DirectXTK](https://github.com/Microsoft/DirectXTK) - A collection of helper classes for writing DirectX 11.x code in C++. [MIT]
 * [GLFW](https://github.com/glfw/glfw) - A simple, cross-platform OpenGL wrangling library. [zlib/libpng]
+* [GLFWPP](https://github.com/janekb04/glfwpp) - A modern C++ wrapper for GLFW. [MIT]
 * [herebedragons](https://github.com/kosua20/herebedragons) - A basic 3D scene implemented with various engines, frameworks or APIs. [MIT] [website](http://simonrodriguez.fr/dragon/)
 * [Horde3D](https://github.com/horde3d/Horde3D) - A small 3D rendering and animation engine. [EPL]
 * [Ion](https://github.com/google/ion) - A small and efficient set of libraries for building cross-platform client or server applications that use 3D graphics. [Apache2] [website](https://google.github.io/ion/)

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Diligent Engine](https://github.com/DiligentGraphics/DiligentEngine) - A modern cross-platform low-level 3D graphics library. [Apache2]
 * [DirectXTK](https://github.com/Microsoft/DirectXTK) - A collection of helper classes for writing DirectX 11.x code in C++. [MIT]
 * [GLFW](https://github.com/glfw/glfw) - A simple, cross-platform OpenGL wrangling library. [zlib/libpng]
-* [GLFWPP](https://github.com/janekb04/glfwpp) - A modern C++ wrapper for GLFW. [MIT]
+* [GLFWPP](https://github.com/janekb04/glfwpp) - A thin modern C++17 header-only wrapper for GLFW. [MIT]
 * [herebedragons](https://github.com/kosua20/herebedragons) - A basic 3D scene implemented with various engines, frameworks or APIs. [MIT] [website](http://simonrodriguez.fr/dragon/)
 * [Horde3D](https://github.com/horde3d/Horde3D) - A small 3D rendering and animation engine. [EPL]
 * [Ion](https://github.com/google/ion) - A small and efficient set of libraries for building cross-platform client or server applications that use 3D graphics. [Apache2] [website](https://google.github.io/ion/)


### PR DESCRIPTION
A thin modern C++17 header-only wrapper for GLFW.