### PR TITLE
Added yaml-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 	- [Virtual Machines](#virtual-machines)
 	- [Web Application Framework](#web-application-framework)
 	- [XML](#xml)
+	- [Yaml](#yaml)
 	- [Miscellaneous](#miscellaneous)
 - [Software](#software)
 	- [Compiler](#compiler)
@@ -908,6 +909,10 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [TinyXML2](https://github.com/leethomason/tinyxml2) - A simple, small, efficient, C++ XML parser that can be easily integrating into other programs. [zlib]
 * [TinyXML++](https://github.com/rjpcomputing/ticpp) - A completely new interface to TinyXML that uses MANY of the C++ strengths. Templates, exceptions, and much better error handling. [MIT]
 * [Xerces-C++](http://xerces.apache.org/xerces-c/) - A validating XML parser written in a portable subset of C++. [Apache2]
+
+## Yaml
+
+* [mini-yaml](https://github.com/jimmiebergmann/mini-yaml) - Single header YAML 1.0 C++11 serializer/deserializer.
 
 ## Miscellaneous
 *Useful libraries or tools that don't fit in the categories above or maybe just not categorised yet*

--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 
 ## Yaml
 
-* [mini-yaml](https://github.com/jimmiebergmann/mini-yaml) - Single header YAML 1.0 C++11 serializer/deserializer.
+* [mini-yaml](https://github.com/jimmiebergmann/mini-yaml) - Single header YAML 1.0 C++11 serializer/deserializer. [MIT]
 
 ## Miscellaneous
 *Useful libraries or tools that don't fit in the categories above or maybe just not categorised yet*

--- a/README.md
+++ b/README.md
@@ -913,6 +913,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 ## Yaml
 
 * [mini-yaml](https://github.com/jimmiebergmann/mini-yaml) - Single header YAML 1.0 C++11 serializer/deserializer. [MIT]
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp) - A YAML parser and emitter in C++ [MIT]
 
 ## Miscellaneous
 *Useful libraries or tools that don't fit in the categories above or maybe just not categorised yet*


### PR DESCRIPTION
This PR adds another yaml library for C++.  This library is also listed on libhunt - https://cpp.libhunt.com/yaml-cpp-alternatives.

> It also includes the commits of #1083, since it needs the Yaml category, which has been added in that PR.
