### PR TITLE
Add WNetWrap to Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Wangle](https://github.com/facebook/wangle) - A client/server application framework to build asynchronous, event-driven modern C++ services. [Apache-2.0]
 * [wdt](https://github.com/facebook/wdt) - An embeddedable library (and command line tool) aiming to transfer data between 2 systems as fast as possible over multiple TCP paths. [BSD-3-Clause]
 * [WebSocket++](https://github.com/zaphoyd/websocketpp) - C++/Boost Asio based websocket client/server library. [BSD]
+* [WNetWrap](https://github.com/hack-tramp/wnetwrap) - C++ WinINet wrapper - tiny windows HTTPS library, no dependencies. [MIT]
 * [PcapPlusPlus](https://github.com/seladb/PcapPlusPlus) - a multiplatform C++ network sniffing and packet parsing and crafting framework. [Unlicense]
 * [ZeroMQ](https://github.com/zeromq/libzmq) - High-speed, modular asynchronous communication library. [LGPL] [website](http://zeromq.org/)
 


### PR DESCRIPTION
[WNetWrap ](https://github.com/hack-tramp/wnetwrap) is a C++ WinINet wrapper - a tiny windows HTTPS library, no dependencies. 