### PR TITLE
Remove broken WebBlog thoughts-on-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,7 +1204,6 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Bartek's Coding Blog](https://www.bfilipek.com/?m=1)
 * [Kenny Kerr](https://kennykerr.ca/articles/)
 * [Sutter’s Mill](https://herbsutter.com/gotw/)
-* [thoughts on cpp](https://thoughts-on-cpp.com/)
 * [Vorbrodt's C++ Blog](https://vorbrodt.blog/)
 * [foonathan::blog()](https://foonathan.net/index.html)
 


### PR DESCRIPTION
• [thoughts-on-cpp](https://thoughts-on-cpp.com) refuses connection for me.
• Assuming its no longer maintained