### PR TITLE
Add inifile-cpp library into the Configuration category

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 ## Configuration
 *Configuration files, INI files*
 
+* [inifile-cpp](https://github.com/Rookfighter/inifile-cpp) - A header-only and easy to use Ini file parser for C++. [MIT]
 * [inih](https://github.com/benhoyt/inih) - Simple .INI file parser in C, good for embedded systems. [BSD-3-Clause]
 * [inih](https://github.com/jtilly/inih) - Single header only C++ version of [inih](https://github.com/benhoyt/inih). [BSD-3-Clause]
 * [iniparser](https://github.com/ndevilla/iniparser) - INI file parser. [MIT]


### PR DESCRIPTION
inifile-cpp is a header-only and easy to use Ini file parser for C++. It has extra very useful functionalities compared to other libraries on the same topic like support to multiple symbols for comments, comments inline, case-insensitive access to sections and fields, etc.