### PR TITLE
Added AREG SDK in the IPC section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 ## Inter-process communication
 
 * [Apache Thrift](https://thrift.apache.org/) - Efficient cross-language IPC/RPC, works between C++, Java, Python, PHP, C#, and many more other languages. Originally developed by Facebook. [Apache2]
+* [AREG SDK](https://github.com/aregtech/areg-sdk) - An interface-centric real-time IPC engine automates messaging and enables distributed computing. [Free/Commercial] [website](https://aregtech.com)
 * [Cap'n Proto](https://github.com/capnproto/capnproto) - Fast data interchange format and capability-based RPC system. [MIT] [website](https://capnproto.org/)
 * [eCAL](https://github.com/continental/ecal) - Pub/sub, client/server, C++/Python/C#, various message protocols (protobuf, capnproto ..). [Apache2] [website](http://www.ecal.io/)
 * [gRPC](https://github.com/grpc/grpc) - A high performance, open source, general-purpose RPC framework. [BSD] [website](http://www.grpc.io/)


### PR DESCRIPTION
Added a link to areg-sdk repository, which is an interface-centric IPC engine written in C++