### PR TITLE
Add poseidon to Memory Allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [snmalloc](https://github.com/microsoft/snmalloc) - Message passing based high-performance allocator. [MIT]
 * [TCMalloc](https://github.com/google/tcmalloc) - Google's fast, multi-threaded malloc implementation. [Apache-2.0] [website](https://google.github.io/tcmalloc/)
 * [tgc](https://github.com/orangeduck/tgc) - A tiny garbage collector for C written in \~500 LOC. [BSD]
+* [poseidon](https://github.com/s0cks/poseidon) - A general purpose allocator and generational garbage collector based on dart/v8's parallel scavenge algorithm. [MIT]
 
 ## Multimedia
 


### PR DESCRIPTION
Adding a project I maintain that implements dart/v8's parallel scavenge algorithm for reference.
~ Tazz

https://github.com/s0cks/poseidon