### PR TITLE
Update books.md

### DIFF
--- a/books.md
+++ b/books.md
@@ -10,7 +10,7 @@
 * [Deep C](http://www.slideshare.net/olvemaudal/deep-c)
 * [Essential C](http://cslibrary.stanford.edu/101/EssentialC.pdf) (PDF)
 * [Learn C the hard way](http://c.learncodethehardway.org/book/)
-* [Object Oriented Programming in C](http://www.planetpdf.com/codecuts/pdfs/ooc.pdf) (PDF)
+* [Object Oriented Programming in C](https://www.cs.rit.edu/~ats/books/ooc.pdf) (PDF)
 * [The C book](http://publications.gbdirect.co.uk/c_book/)
 * [The Craft of Text Editing or A Cookbook for an Emacs](http://www.finseth.com/craft/) - Craig A. Finseth
 * [The GNU C Programming Tutorial](http://www.crasseux.com/books/ctut.pdf)


### PR DESCRIPTION
"http://www.planetpdf.com/codecuts/pdfs/ooc.pdf" is a dead link now. This link is not working at all. The book is available at this added link: (https://www.cs.rit.edu/~ats/books/ooc.pdf)