### PR TITLE
Add libpqxx

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [hiberlite](https://github.com/paulftw/hiberlite) - C++ Object-relational mapping for sqlite3. [BSD]
 * [Hiredis](https://github.com/redis/hiredis) - A minimalistic C client library for the Redis database. [BSD]
 * [LevelDB](https://github.com/google/leveldb) - A fast key-value storage library written at Google that provides an ordered mapping from string keys to string values. [BSD]
+* [libpqxx](https://github.com/jtv/libpqxx) - The official C++ client API for PostgreSQL.
 * [LMDB](http://symas.com/mdb/) - Very fast embedded key/value store with full ACID semantics. [OpenLDAP]
 * [LMDB++](https://github.com/bendiken/lmdbxx) - C++11 wrapper for the LMDB embedded database library. [PublicDomain]
 * [MongoDB C Driver](https://github.com/mongodb/mongo-c-driver) - MongoDB client library for C. [Apache2]


### PR DESCRIPTION
Added to Database [libpqxx](https://pqxx.org/libpqxx/) which is the official C++ client API for PostgreSQL. [BSD-3-Clause]