### PR TITLE
Add tar_to_stream.h to compression libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Minizip](https://github.com/nmoinvaz/minizip) - Zlib with latest bug fixes that supports PKWARE disk spanning, AES encryption, and IO buffering. [zlib]
 * [smaz](https://github.com/antirez/smaz) - Small strings compression library. [BSD]
 * [Snappy](https://google.github.io/snappy/) - A fast compressor/decompressor. [BSD]
+* [tar_to_stream.h](https://github.com/Armchair-Software/tar_to_stream) - A tiny header-only library for creating TAR archives from memory, writing to a stream.
 * [ZLib](http://zlib.net/) - A very compact compression library for data streams. [zlib]
 * [zlib-ng](https://github.com/Dead2/zlib-ng) - zlib for the "next generation" systems. Drop-In replacement with some serious optimizations. [zlib]
 * [zstd](https://github.com/facebook/zstd) - Zstandard - Fast real-time compression algorithm. Developed by Facebook. [BSD]


### PR DESCRIPTION
Adds https://github.com/Armchair-Software/tar_to_stream library to the list of compression libraries