### PR TITLE
Add a lightening icon to C++ Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [ASL](http://stlab.adobe.com/) - Adobe Source Libraries provides peer-reviewed and portable C++ source libraries. [MIT]
 * [Boost](https://github.com/boostorg) :zap: - A large collection of generic C++ libraries. [Boost] [website](https://www.boost.org)
 * [BDE](https://github.com/bloomberg/bde) - The BDE Development Environment from Bloomberg Labs. [Apache2]
-* [C++ Workflow](https://github.com/sogou/workflow) - C++ Parallel Computing and Asynchronous Networking Engine. [Apache2]
+* [C++ Workflow](https://github.com/sogou/workflow) :zap: - C++ Parallel Computing and Asynchronous Networking Engine. [Apache2]
 * [CGraph](https://github.com/ChunelFeng/CGraph) - A cross-platform DAG framework based on C++ without any 3rd-party. [MIT]
 * [Cinder](https://libcinder.org/) - A community-developed, free and open source library for professional-quality creative coding. [BSD]
 * [Coost](https://github.com/idealvin/coost) - A tiny boost library in C++11. [MIT]


### PR DESCRIPTION
Reasons:

**1. More than 10000 stars.**

**2. Packaged by Debian Linux and ubuntu 22.04.** 

reference: [https://launchpad.net/ubuntu/+source/workflow](https://launchpad.net/ubuntu/+source/workflow)

To install the Workflow library for development purposes or for deployment:
```
sudo apt-get install libworkflow-dev
```
```
sudo apt-get install libworkflow1
```

**3. Packaged by Fedora Linux.**

reference: [https://packages.fedoraproject.org/pkgs/workflow](https://packages.fedoraproject.org/pkgs/workflow/)

To install the Workflow library for development purposes or for deployment:

```
sudo dnf install workflow-devel
```
```
sudo dnf install workflow
```

**4. CNCF landscape Platform/PAAS project.**

reference: [https://landscape.cncf.io/?selected=sogou-c-workflow](https://landscape.cncf.io/?selected=sogou-c-workflow)

<img width="693" alt="image" src="https://user-images.githubusercontent.com/1880011/228501746-9080aab8-41b2-4f10-b780-02b0fc18bd83.png">

We are constantly working to make the project better and benefit more developers. It would be very appreciated if this is acceptable.