### PR TITLE
The license of ZeroMQ has been changed to MPL2 since 4.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [wdt](https://github.com/facebook/wdt) - An embeddedable library (and command line tool) aiming to transfer data between 2 systems as fast as possible over multiple TCP paths. [BSD-3-Clause]
 * [WebSocket++](https://github.com/zaphoyd/websocketpp) - C++/Boost Asio based websocket client/server library. [BSD]
 * [PcapPlusPlus](https://github.com/seladb/PcapPlusPlus) - a multiplatform C++ network sniffing and packet parsing and crafting framework. [Unlicense]
-* [ZeroMQ](https://github.com/zeromq/libzmq) - High-speed, modular asynchronous communication library. [LGPL] [website](http://zeromq.org/)
+* [ZeroMQ](https://github.com/zeromq/libzmq) - High-speed, modular asynchronous communication library. [LGPL3/MPL2] [website](http://zeromq.org/)
 
 ## PDF
 *Libraries for parsing and manipulating PDF documents.*


### PR DESCRIPTION
Reference:
https://github.com/zeromq/libzmq/releases/tag/v4.3.5