### PR TITLE
add haclog (logging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [fmtlog](https://github.com/MengRao/fmtlog) - A performant fmtlib-style logging library with latency in nanoseconds. [MIT]
 * [G3log](https://github.com/KjellKod/g3log) - Asynchronous logger with Dynamic Sinks. [PublicDomain]
 * [glog](https://github.com/google/glog) - C++ implementation of the Google logging module.
+* [haclog](https://github.com/MuggleWei/haclog) - An extremely fast plain C logging library. [MIT]
 * [Log4cpp](http://log4cpp.sourceforge.net/) - A library of C++ classes for flexible logging to files, syslog, IDSA and other destinations. [LGPL]
 * [log4cplus](https://github.com/log4cplus/log4cplus) - A simple to use C++ logging API providing thread-safe, flexible, and arbitrarily granular control over log management and configuration. [BSD & Apache2]
 * [loguru](https://github.com/emilk/loguru) - A lightweight C++ logging library. [PublicDomain]


### PR DESCRIPTION
haclog is an extremely fast plain C logging library.
Here a benchmark([cc_log_benchmark](https://github.com/MuggleWei/cc_log_benchmark)) that demonstrates this visually.