### PR TITLE
Remove uSTL (github repo has been deleted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [STXXL](http://stxxl.sourceforge.net/) - Standard Template Library for Extra Large Data Sets. [Boost]
 * [tbox](https://github.com/tboox/tbox) - A glib-like multi-platform c library. [Apache2] [website](http://tboox.org/)
 * [Ultimate++](http://www.ultimatepp.org/) - A C++ cross-platform rapid application development framework. [BSD]
-* [uSTL](http://msharov.github.io/ustl/) - The small STL library. [MIT]
 * [Windows Template Library](http://sourceforge.net/projects/wtl/) - A C++ library for developing Windows applications and UI components. [Public]
 * [Yomm2](https://github.com/jll63/yomm2) - Fast, Orthogonal, Open multi-methods. Supersedes [Yomm11](https://github.com/jll63/yomm11) [Boost]
 


### PR DESCRIPTION
The `uSTL` ` github re o has been deleted: https://msharov.github.io/ustl/ (or https://github.com/msharov/ustl)
Even the SourceForce project has been deleted too: https://sourceforge.net/projects/ustl or http://ustl.sourceforge.net/