### PR TITLE
Add Sccache compiler cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1284,6 +1284,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Hunter](https://www.github.com/ruslo/hunter) - CMake driven cross-platform package manager for C++. [BSD-2]
 * [MesonBuild](http://mesonbuild.com) - An open source build system meant to be both extremely fast, and, even more importantly, as user friendly as possible.
 * [Ninja](https://ninja-build.org/) - A small build system with a focus on speed.
+* [Sccache](https://github.com/mozilla/sccache) - A fast compiler cache for C/C++, with cross-platform support and cloud backed storage options.
 * [Scons](http://www.scons.org/) - A software construction tool configured with a Python script.
 * [Sconsolidator](http://www.sconsolidator.com/) - Scons build system integration for Eclipse CDT.
 * [Spack](https://spack.io/) - A flexible package manager that supports multiple versions, configurations, platforms, and compilers. [Apache-2.0/MIT]


### PR DESCRIPTION
Adding link to Mozilla sccache, a ccache-like ( #1520 ) compiler cache.