### PR TITLE
Add gplot++

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 ## Data visualization
 *Data visualization Libraries*
 
+* [gplot++](https://github.com/ziotom78/gplotpp) - Cross-platform header-only C++ plotting library that interfaces with Gnuplot. [MIT]
 * [matplotplusplus](https://github.com/alandefreitas/matplotplusplus) - C++ Graphics Library for Data Visualization. [MIT] [website](https://alandefreitas.github.io/matplotplusplus/)
 
 ## Debug


### PR DESCRIPTION
gplot++ is a plotting library that interfaces with Gnuplot. Many plotting libraries are listed under the “GUI” section, but I put this new entry under “Data visualization” because it seems more appropriate to me. (The library can open a window containing the plot, but it can also redirect the plot to an image file; in this case, there is no window at all.)