### PR TITLE
Modern C++14 sigslot implementation has been added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [SDS](https://github.com/antirez/sds) - Simple Dynamic Strings library for C. [BSD]
 * [semver.c](https://github.com/h2non/semver.c) - A semver parser and render in ANSI C. [MIT]
 * [sigslot](http://sigslot.sourceforge.net/) - C++ Signal/Slot Library. [PublicDomain]
+* [palacaze/sigslot](https://github.com/palacaze/sigslot) - A simple, header only, C++14 signal-slots implementation [MIT]
 * [simdzone](https://github.com/NLnetLabs/simdzone) - Fast and standards compliant DNS zone parser. [BSD-3-Clause]
 * [SimpleSignal](https://github.com/larspensjo/SimpleSignal) - High performance C++11 signals. [PublicDomain]
 * [Stage](https://github.com/rtv/Stage) - Mobile robot simulator. [GPL2]


### PR DESCRIPTION
I found out this very smart, headers only, and modern sigslot library. 
Consider to remove `[sigslot](http://sigslot.sourceforge.net/) - C++ Signal/Slot Library. [PublicDomain]` It's bit old and not mantained.