### PR TITLE
Add CrashCatch to Debug Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [CppBenchmark](https://github.com/chronoxor/CppBenchmark) - Performance benchmark framework for C++ with nanoseconds measure precision. [MIT]
 * [Cpptrace](https://github.com/jeremy-rifkin/cpptrace) - A simple, portable, and self-contained C++ stacktrace library supporting C++11 and greater. [MIT]
 * [CppUnit](http://www.freedesktop.org/wiki/Software/cppunit/) - C++ port of JUnit. [LGPL2]
+* [CrashCatch](https://github.com/keithpotz/CrashCatch) - Single-header crash reporting for C++ that logs stack traces and creates `.dmp` and `.txt` crash dumps. [MIT] [website](https://keithpotz.github.io/CrashCatch)
 * [CTest](https://cmake.org/cmake/help/v2.8.8/ctest.html) - The CMake test driver program. [BSD]
 * [dbg-macro](https://github.com/sharkdp/dbg-macro) - A dbg(…) macro for C++. [MIT]
 * [DebugViewPP](https://github.com/CobaltFusion/DebugViewPP) - Debug logging viewer. [Boost]


### PR DESCRIPTION
CrashCatch is a lightweight, single-header crash reporting library for modern C++ applications. It provides an easy way to automatically capture stack traces and write crash logs in .dmp and .txt formats. This update adds CrashCatch to the "Debug" section of the documentation to make it more accessible to developers looking for a simple and effective debugging tool for crash handling in C++.

- MIT Licensed
- Header-only, zero dependencies
- One-line setup or macro auto-init for minimal integration
- Website: https://keithpotz.github.io/CrashCatch