### PR TITLE
Add utl::profiler: Single-header profiler for C++17.

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [UnitTest++](https://github.com/unittest-cpp/unittest-cpp) - A lightweight unit testing framework for C++. [MIT/X Consortium license]
 * [Unity](https://github.com/ThrowTheSwitch/Unity) - Simple Unit Testing for C. [MIT]
 * [utest.h](https://github.com/sheredom/utest.h) - Single header unit testing framework for C and C++. [Unlicense]
+* [utl::profiler](https://github.com/DmitriBogdanov/UTL/blob/master/docs/module_profiler.md) - Singe-header profiler for C++17. [MIT]
 * [μt](https://github.com/boost-experimental/ut) - C++20 single header/single module, macro-free μ(micro)/Unit Testing Framework. [Boost]
 * [VLD](https://kinddragon.github.io/vld//) - Visual Leak Detector. A free, robust, open-source memory leak detection system for Visual C++.
 


### PR DESCRIPTION
Singe-header profiler for C++17.

Works on every platform with a compliant compiler, supports multi-threaded and recursive workloads.

Focuses on the ease of integration and embedded support.

Link to the documentation: https://github.com/DmitriBogdanov/UTL/blob/master/docs/module_profiler.md
Link to the header: https://github.com/DmitriBogdanov/UTL/blob/master/include/UTL/profiler.hpp

There are other libs managed under the same repo, but this is simply a convenience choice, they are all independent single-header libs and can be used in isolation.

MIT license.