### PR TITLE
Add mexce - single-header JIT math expression compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [linalg.h](https://github.com/sgorsten/linalg) - Single header, public domain, short vector math library for C++. [Unlicense]
 * [MATIO](https://github.com/tbeu/matio) -  MATLAB MAT File I/O Library. [BSD-2-Clause] [website](https://sourceforge.net/projects/matio/)
 * [MatX](https://github.com/NVIDIA/MatX) - A GPU-accelerated C++17 numerical computing library with a MATLAB/Python-like syntax. [BSD 3-clause]
+* [mexce](https://github.com/imakris/mexce) - A single-header, dependency-free JIT compiler for scalar mathematical expressions that generates optimized x87 FPU machine code. [BSD]
 * [MIRACL](https://github.com/CertiVox/MIRACL) - A Multiprecision Integer and Rational Arithmetic Cryptographic Library. [AGPL]
 * [NumCpp](https://github.com/dpilger26/NumCpp) - A templatized header only C++ implementation of the Python Numpy library. [MIT]
 * [OMath](https://github.com/orange-cpp/omath) - Cross-platform modern general purpose math library written in C++23 that suitable for cheat/game development. [ZLIB]


### PR DESCRIPTION
This PR adds [mexce](https://github.com/imakris/mexce) to the Math section.

**Proposed Entry:**
* [mexce](https://github.com/imakris/mexce) - A single-header, dependency-free JIT compiler for scalar mathematical expressions that generates optimized x87 FPU machine code. [BSD]

**Key Features:**
* **Single-header & dependency-free:** Easy to integrate.
* **JIT compilation:** Compiles expressions to native x87 FPU code at runtime for high performance.
* **Well-documented:** Includes a comprehensive README and benchmark suite.

This library is stable, with a `v1.0.0` release and I believe it would be a valuable addition to the list.
