### PR TITLE
Updated Autosar C++ 2014 guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1472,7 +1472,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 
 * [Cert C++](https://resources.sei.cmu.edu/downloads/secure-coding/assets/sei-cert-cpp-coding-standard-2016-v01.pdf)
 * [Misra C++ 2008](https://www.cppdepend.com/misra-cpp)
-* [Autosar C++ 2014](https://www.autosar.org/fileadmin/standards/adaptive/21-11/AUTOSAR_RS_CPP14Guidelines.pdf)
+* [Autosar C++ 2014](https://www.autosar.org/fileadmin/standards/R21-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf)
 
 ## Coding Style
 


### PR DESCRIPTION
Hi,

I was looking at the [coding standards](https://github.com/fffaraz/awesome-cpp?tab=readme-ov-file#coding-standards) section of the README and noticed that the link for "Autosar C++ 2014" is broken?

There are many [results](https://www.autosar.org/search?tx_solr%5Bq%5D=C%2B%2B+14+guidelines) for C++ documents on the [Autosar](https://www.autosar.org/) website, although [this](https://www.autosar.org/fileadmin/standards/R21-11/AP/[AUTOSAR_RS_CPP14Guidelines.pdf) appears to be the correct document.

I say this because the original URL has "21-11" in it, and so does this document on the official website.

<p>
<img src="https://github.com/user-attachments/assets/ddf73811-9f77-4baf-b619-a66010cdbcda" alt="21-11" width="100%" style="max-width: 100%;">
</p>

<p>
<img src="https://github.com/user-attachments/assets/19b8f751-32d4-4ecf-94a1-0345c5e8f0a5" alt="Result" width="80%" style="max-width: 100%;">
</p>

Let me know your thoughts.

-- Nikki