### PR TITLE
Add Doxytest to the list of tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [dbg-macro](https://github.com/sharkdp/dbg-macro) - A dbg(…) macro for C++. [MIT]
 * [DebugViewPP](https://github.com/CobaltFusion/DebugViewPP) - Debug logging viewer. [Boost]
 * [Deleaker](http://www.deleaker.com) - A tool for resource leak detection, including memory, GDI and handle leaks.
+* [Doxytest](https://github.com/nessan/doxytest) - Extract test code from documentation -- Rust-style doctests for C++. [MIT]
 * [FakeIt](https://github.com/eranpeer/FakeIt) - Simple mocking framework for C++. [MIT]
 * [fff](https://github.com/meekrosoft/fff) - A micro-framework for creating fake C functions. [MIT]
 * [Google Mock](https://github.com/google/googletest/blob/master/googlemock/README.md) - A library for writing and using C++ mock classes. [BSD]


### PR DESCRIPTION
Doxytest is a tool that extracts test code from documentation, for example, from comments before a method or a class. Rust's doctests are the inspiration for Doxytest.