### PR TITLE
Add cryptopp-modern to cryptography libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [BeeCrypt](http://beecrypt.sourceforge.net/) - A portable and fast cryptography library. [LGPLv2.1+]
 * [Botan](http://botan.randombit.net/) - A crypto library for C++. [BSD-2]
 * [Crypto++](https://github.com/weidai11/cryptopp) - A free C++ class library of cryptographic schemes. [Boost] [website](http://www.cryptopp.com/)
+* [cryptopp-modern](https://github.com/cryptopp-modern/cryptopp-modern) - A fork of Crypto++ that adds modern build systems, new algorithms, and refreshed documentation. [Boost] [website](https://cryptopp-modern.com/)
 * [digestpp](https://github.com/kerukuro/digestpp) - C++11 header-only message digest (hash) library. [PublicDomain]
 * [GnuPG](https://www.gnupg.org/) - A complete and free implementation of the OpenPGP standard. [GPL]
 * [GnuTLS](http://www.gnutls.org/) - A secure communications library implementing the SSL, TLS and DTLS protocols. [LGPL2.1]


### PR DESCRIPTION
This PR adds cryptopp-modern to the Cryptography section.

cryptopp-modern is a fork of Crypto++ that:
- keeps the codebase maintained and up to date,
- adds modern build systems (CMake, GNUmakefile, etc.),
- includes additional algorithms such as Argon2 and BLAKE3,
- and provides refreshed documentation at https://cryptopp-modern.com/.

Listing it alongside Crypto++ makes it easier for C++ users to find an actively maintained variant with a more modern toolchain and documentation.
