### PR TITLE
Add FunctionTraits to Reflection section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,6 +1022,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [CPFG](https://github.com/cpgf/cpgf) - A C++03 library for reflection, callback and script binding. [Apache2]
 * [CPP-Reflection](https://github.com/AustinBrunkhorst/CPP-Reflection) - C++ Reflection using clang. [MIT]
 * [Easy Reflection](https://github.com/chocolacula/easy_reflection_cpp) - Easy and fast reflection + serialization solution like in Rust, Java or Go. [Apache]
+* [FunctionTraits](https://github.com/HexadigmSystems/FunctionTraits) - A C++17 single header-only library for retrieving function traits (arg types, arg count, return type, etc.) at compile-time. [MIT]
 * [Magic Enum](https://github.com/Neargye/magic_enum) - Header-only C++17 library provides static reflection for enums (to string, from string, iteration), work with any enum type without any macro or boilerplate code. [MIT]
 * [magic_get](https://github.com/apolukhin/magic_get) - std::tuple like methods for user defined types without any macro or boilerplate code. [Boost]
 * [meta](https://github.com/skypjack/meta) - Header-only, non-intrusive and macro-free runtime reflection system in C++. [MIT]


### PR DESCRIPTION
## Description
This PR adds [FunctionTraits](https://github.com/HexadigmSystems/FunctionTraits) to the Reflection section.

**FunctionTraits** is a C++17 single header-only library for retrieving function traits at compile-time, including:
- Function argument types and count
- Return type
- Calling conventions
- cv-qualifiers, noexcept specification, and more

The library is well-documented, actively maintained, and MIT licensed.

Closes #1680