### PR TITLE
Add dispenso to Concurrency section

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [cuda-api-wrappers](https://github.com/eyalroz/cuda-api-wrappers) - Lightweight, Modern-C++ wrappers for the CUDA GPU programming runtime API. [BSD]
 * [cupla](https://github.com/ComputationalRadiationPhysics/cupla) - C++ API to run CUDA/C++ on OpenMP, Threads, TBB, ... through Alpaka. [LGPLv3+]
 * [C++React](https://github.com/schlangster/cpp.react) - A reactive programming library for C++11. [Boost]
+* [dispenso](https://github.com/facebookincubator/dispenso) - A high-performance C++ library for parallel programming with thread pools, parallel for loops, futures, task graphs, and concurrent containers. [MIT]
 * [FiberTaskingLib](https://github.com/RichieSams/FiberTaskingLib) - Task-based multi-threading library that supports task graphs with arbitrary dependencies. [Apache]
 * [HPX](https://github.com/STEllAR-GROUP/hpx/) - A general purpose C++ runtime system for parallel and distributed applications of any scale. [Boost]
 * [Intel Games Task Scheduler](https://github.com/GameTechDev/GTS-GamesTaskScheduler) - A task scheduling framework designed for the needs of game developers. [MIT]


### PR DESCRIPTION
Add [dispenso](https://github.com/facebookincubator/dispenso), a high-performance C++ library for parallel programming from Meta.

**Features:**
- Work-stealing thread pools
- Parallel for loops
- Futures with std::experimental::future-like API
- Task graphs and pipelines
- Concurrent containers (ConcurrentVector)

It's used in hundreds of projects at Meta and offers advantages over OpenMP and TBB for nested parallelism and sanitizer compatibility (ASAN/TSAN clean).

**License:** MIT