### PR TITLE
Add ManasPDF library to PDF libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 
 * [libharu](https://github.com/libharu/libharu) - A free, cross platform, open-sourced software library for generating PDF. [zlib]
 * [litePDF](https://litepdf.sourceforge.io) - Library to create and edit PDF documents that uses GDI functions through a device context to draw the page content. [LGPL v3 and zlib]
+* [ManasPDF](https://github.com/Informal061/ManasPDF) - A PDF rendering and viewing library with Direct2D hardware rendering, .NET 8 wrapper and WPF control. Editing capabilities are in development. [Apache-2.0]
 * [MuPDF](https://mupdf.com/) - A lightweight PDF, XPS, and E-book viewer. [AGPL/Proprietary]
 * [PDF-Writer](https://github.com/galkahana/PDF-Writer) - High performance library for creating, modiyfing and parsing PDF files in C++ [Apache-2.0] [website](https://www.pdfhummus.com/)
 * [pdfio](https://github.com/michaelrsweet/pdfio) - A simple C library for reading and writing PDF files. [Apache-2] [website](https://www.msweet.org/pdfio/)


### PR DESCRIPTION
Adding ManasPDF - a PDF rendering engine written in C++ using Direct2D for hardware-accelerated rendering with automatic CPU software fallback.

- GitHub: https://github.com/Informal061/ManasPDF
- License: Apache 2.0
- Website: https://thebigstudio.net/en/ManasPDF
