### PR TITLE
Add SlothDB to Database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Reindexer](https://github.com/Restream/reindexer) - Embeddable, in-memory, document-oriented database with a high-level Query builder interface. [Apache2] [website](https://reindexer.io/)
 * [RocksDB](https://github.com/facebook/rocksdb) - Embedded key-value store for fast storage from facebook. [BSD]
 * [SimDB](https://github.com/LiveAsynchronousVisualizedArchitecture/simdb) - High performance, shared memory, lock free, cross platform, single file, minimal dependencies, C++11 key-value store. [Apache2]
+* [SlothDB](https://github.com/SouravRoy-ETL/slothdb) - An embedded analytical database engine with GPU acceleration. Query CSV, Parquet, JSON, Excel directly with SQL. Zero dependencies. [MIT] [website](https://souravroy-etl.github.io/slothdb/)
 * [SOCI](https://github.com/SOCI/soci) - A database abstraction layer for C++. [Boost]
 * [Speedb](https://github.com/speedb-io/speedb) - Community-led project: A RocksDB compliant high performance scalable embedded key-value store. [Apache2]
 * [sqlgen](https://github.com/getml/sqlgen) - A reflection-based ORM and SQL query generator for C++-20, similar to Python's SQLAlchemy/SQLModel or Rust's Diesel. [MIT]


### PR DESCRIPTION
## Add SlothDB

[SlothDB](https://github.com/SouravRoy-ETL/slothdb) is an embedded analytical database engine (OLAP) written in C++20 with zero external dependencies.

**Why it belongs here:**
- In-process embedded database like DuckDB, SQLite
- Written entirely in C++20 with no external dependencies
- GPU accelerated (CUDA + Metal)
- 7 built-in file format readers (CSV, Parquet, JSON, Excel, Arrow, Avro, SQLite)
- 130+ SQL features, 325 tests
- MIT licensed
- Active development, CI on Windows/Linux/macOS

**Placement:** Database section, alphabetical order after SimDB.