### PR TITLE
Add geo-utils to Math

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Eigen](http://eigen.tuxfamily.org/) - A high-level C++ library of template headers for linear algebra, matrix and vector operations, numerical solvers and related algorithms. [MPL2]
 * [ExprTk](https://www.partow.net/programming/exprtk/) - The C++ Mathematical Expression Toolkit Library (ExprTk) is a simple to use, easy to integrate and extremely efficient run-time mathematical expression parser and evaluation engine. [MIT]
 * [Fastor](https://github.com/romeric/Fastor) - A lightweight high performance tensor algebra framework for modern C++. [MIT]
+* [geo-utils](https://github.com/gistrec/geo-utils) - Header-only C++17 library for spherical lat/lng geometry: distance, bearing, area, point-in-polygon. [Apache2]
 * [Geometric Tools](https://www.geometrictools.com) - C++ library for computing in the fields of mathematics, graphics, image analysis and physics. [Boost] [website](https://www.geometrictools.com)
 * [GLM](https://github.com/g-truc/glm) - Header-only C++ math library that matches and inter-operates with OpenGL's GLSL math. [MIT] [website](https://glm.g-truc.net/)
 * [GMTL](http://ggt.sourceforge.net/) - Graphics Math Template Library is a collection of tools implementing Graphics primitives in generalized ways. [GPL2]


### PR DESCRIPTION
Adds [geo-utils](https://github.com/gistrec/geo-utils), a header-only C++17 library for spherical (lat/lng) geometry — distance, bearing, area, point-in-polygon, and path proximity on Earth coordinates.

- License: Apache-2.0
- Header-only, no runtime dependencies
- C++17, CMake 3.14+ (CMake config + imported target `geo::utils`)
- CI on Linux (gcc/clang), macOS, Windows; downstream `find_package` smoke-tested on all three

Inserted alphabetically in the Math section between `Fastor` and `Geometric Tools`.

Checklist (per CONTRIBUTING.md):
- [x] Searched for duplicates — no existing entry for geo-utils
- [x] Single suggestion per PR
- [x] Format: `[name](repo) - description. [License]`
- [x] Description ends with a period
- [x] Inserted in alphabetical order within the category
