### PR TITLE
Rename geo-utils to geo-utils-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,7 +892,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Eigen](http://eigen.tuxfamily.org/) - A high-level C++ library of template headers for linear algebra, matrix and vector operations, numerical solvers and related algorithms. [MPL2]
 * [ExprTk](https://www.partow.net/programming/exprtk/) - The C++ Mathematical Expression Toolkit Library (ExprTk) is a simple to use, easy to integrate and extremely efficient run-time mathematical expression parser and evaluation engine. [MIT]
 * [Fastor](https://github.com/romeric/Fastor) - A lightweight high performance tensor algebra framework for modern C++. [MIT]
-* [geo-utils](https://github.com/gistrec/geo-utils) - Header-only C++17 library for spherical lat/lng geometry: distance, bearing, area, point-in-polygon. [Apache2]
+* [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) - Header-only C++17 library for spherical lat/lng geometry: distance, bearing, area, point-in-polygon. [Apache2]
 * [Geometric Tools](https://www.geometrictools.com) - C++ library for computing in the fields of mathematics, graphics, image analysis and physics. [Boost] [website](https://www.geometrictools.com)
 * [GLM](https://github.com/g-truc/glm) - Header-only C++ math library that matches and inter-operates with OpenGL's GLSL math. [MIT] [website](https://glm.g-truc.net/)
 * [GMTL](http://ggt.sourceforge.net/) - Graphics Math Template Library is a collection of tools implementing Graphics primitives in generalized ways. [GPL2]


### PR DESCRIPTION
The library [previously added](https://github.com/fffaraz/awesome-cpp/pull/1831) as `geo-utils` was renamed to `geo-utils-cpp` to avoid a Repology naming conflict (see gistrec/geo-utils-cpp#11).

This PR updates the existing entry in the **Math** section to use the new name and URL:

- Link text: `geo-utils` → `geo-utils-cpp`
- URL: `https://github.com/gistrec/geo-utils` → `https://github.com/gistrec/geo-utils-cpp`

The old URL still redirects, but the rename means future linking should use the new canonical name. Description, license tag (`[Apache2]`), and alphabetical position are unchanged.

Checklist (per CONTRIBUTING.md):
- [x] Single suggestion per PR
- [x] Format: `[name](repo) - description. [License]`
- [x] Description ends with a period
- [x] Alphabetical order preserved