### PR TITLE
Add Sourcey to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [doxyrest](https://github.com/vovkos/doxyrest) - A compiler from Doxygen XML to reStructuredText for Sphinx. [MIT]
 * [hdoc](https://github.com/hdoc/hdoc) - The modern documentation tool for C++. [AGPL/Proprietary] [website](https://hdoc.io)
 * [Natural Docs](https://github.com/NaturalDocs/NaturalDocs) - Natural Docs is an open source documentation generator for multiple programming languages. [AGPL/Proprietary] [website](https://www.naturaldocs.org)
+* [Sourcey](https://github.com/sourcey/sourcey) - Static documentation generator that consumes Doxygen XML alongside OpenAPI, godoc, MCP, and Markdown. [AGPL-3.0] [website](https://sourcey.com)
 * [Sphinx](https://github.com/sphinx-doc/sphinx) - Sphinx makes it easy to create intelligent and beautiful documentation. [BSD-2-Clause] [website](https://www.sphinx-doc.org)
 
 ## DSP


### PR DESCRIPTION
Sourcey (https://sourcey.com) is a static documentation generator that consumes Doxygen XML output alongside OpenAPI, godoc, MCP, and Markdown sources to produce one cohesive static HTML site. It is not itself a C++ library, but it fits the Documentation section on the same footing as doxyrest and Sphinx (downstream consumers of Doxygen output rather than C++ libraries themselves).

For C++ projects already using Doxygen, the path is to keep the Doxyfile, set GENERATE_XML = YES, and point Sourcey at the XML output. No new parser, no four-tool Breathe/Exhale/Sphinx pipeline.

- Project: https://sourcey.com
- Live example on a C++ project: https://0state.com/icey/docs
- Source: https://github.com/sourcey/sourcey
- License: AGPL-3.0

The entry follows this list's CONTRIBUTING.md format, which uses the GitHub URL as the primary anchor and a separate [website] tag for the product page.