### PR TITLE
Add cofetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Restbed](https://github.com/corvusoft/restbed) - C++11 Asynchronous RESTful framework. [AGPL]
 * [Restinio](https://github.com/Stiffstream/restinio) - A header-only C++14 library that gives you an embedded HTTP/Websocket server. [BSD]
 * [c-ares](https://github.com/c-ares/c-ares) - A C library for asynchronous DNS requests. [MIT]
+* [cofetch](https://github.com/SSARCandy/cofetch) - Chainable async HTTP client built on libcurl's multi interface and ASIO. Callbacks, coroutines and futures from one implementation. [MIT]
 * [cpp-httplib](https://github.com/yhirose/cpp-httplib) - A single file C++11 header-only HTTP/HTTPS server library. [MIT]
 * [cpp-netlib](http://cpp-netlib.org/) - A collection of open-source libraries for high level network programming. [Boost]
 * [cpp-netlib/uri](https://github.com/cpp-netlib/uri) - URI parser/builder library for C++, compatible with RFC 3986 and RFC 3987. [Boost]


### PR DESCRIPTION
Adds [cofetch](https://github.com/SSARCandy/cofetch) to the Networking section.

cofetch is a chainable, async HTTP client for C++ event loops, built on libcurl's multi interface and standalone/Boost ASIO. One implementation serves plain callbacks, C++20 coroutines, std::future and deferred chains; ships with benchmarks against cpr and cpp-httplib. Header-only, C++17 and up, MIT licensed, CI-tested on Linux/macOS.

Entry is in alphabetical order with the license noted, per the contribution guidelines.