### PR TITLE
Add MessageFrame to Networking section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,7 @@ A curated list of awesome C++ (or C) frameworks, libraries, resources, and shiny
 * [Lithium](https://matt-42.github.io/lithium/) - Build high performance C++ HTTP servers without being a C++ expert. [MIT]
 * [lwIP](https://savannah.nongnu.org/projects/lwip/) - A lightweight TCP/IP stack. [Modified BSD]
 * [mailio](https://github.com/karastojko/mailio) - mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols. [BSD]
+* [MessageFrame](https://github.com/stubcpp/MessageFrame) - A lightweight, schema-less C++17 library for structured network messages and telemetry serialization without code generation.
 * [Mongoose](https://github.com/cesanta/mongoose) - Extremely lightweight webserver. [GPL2]
 * [MQTT-C](https://github.com/LiamBindle/MQTT-C) - A portable MQTT C client for embedded systems and PCs alike. [MIT] [website](https://liambindle.ca/MQTT-C)
 * [mTCP](https://github.com/mtcp-stack/mtcp) - Highly scalable user-level TCP stack for multicore systems. [Modified BSD]


### PR DESCRIPTION
Hello! I would like to suggest adding **MessageFrame** to the Networking section. 

It is a lightweight, schema-less C++17 library specifically designed for structured network telemetry and command exchange. It bypasses the need for heavy code-generation workflows (like Protobuf) by using a highly optimized dynamic layout combined with a zero-copy attachments mechanism for heavy binary payloads. It is production-ready, open-source (MIT), and fully self-contained.

Thank you for maintaining this awesome list!
